### PR TITLE
I've made a change to fix the alpha-beta search so it uses the correc…

### DIFF
--- a/chess_engine.py
+++ b/chess_engine.py
@@ -92,7 +92,7 @@ class Engine:
                 # No alpha cutoff at root for all moves, but beta helps ordering for future.
             return best_move_found
 
-    def alpha_beta_search(self, current_board, depth, alpha, beta, is_maximizing_player_for_eval, original_fen_for_eval):
+    def alpha_beta_search(self, current_board, depth, alpha, beta, is_maximizing_player_for_eval, parent_fen_for_eval):
         if current_board.is_game_over():
             if current_board.is_checkmate():
                 # current_board.turn is the player who IS mated.
@@ -101,24 +101,25 @@ class Engine:
                 else: # Black is mated (White delivered mate)
                     return CHECKMATE_POSITIVE_SCORE
             # For other game over conditions (stalemate, etc.), let the model evaluate.
-            # The evaluate_pos function compares original_fen_for_eval to current_board.fen()
+            # The evaluate_pos function compares parent_fen_for_eval to current_board.fen()
             # This will give a score from White's perspective.
-            return evaluate_pos(original_fen_for_eval, current_board.fen())
+            return evaluate_pos(parent_fen_for_eval, current_board.fen())
 
         if depth == 0:
-            return evaluate_pos(original_fen_for_eval, current_board.fen())
+            return evaluate_pos(parent_fen_for_eval, current_board.fen())
 
         legal_moves_ab = list(current_board.legal_moves)
         if not legal_moves_ab: # Should be caught by is_game_over, but as a safeguard
-             return evaluate_pos(original_fen_for_eval, current_board.fen())
+             return evaluate_pos(parent_fen_for_eval, current_board.fen())
 
+        fen_of_board_at_this_level = current_board.fen()
 
         if is_maximizing_player_for_eval: # White's turn in search tree (wants to maximize White's score)
             current_max_eval = float('-inf')
             for move in legal_moves_ab:
                 current_board.push(move)
                 # Next player (Black) is minimizing. Depth is current_depth - 1.
-                eval_score = self.alpha_beta_search(current_board, depth - 1, alpha, beta, False, original_fen_for_eval)
+                eval_score = self.alpha_beta_search(current_board, depth - 1, alpha, beta, False, fen_of_board_at_this_level)
                 current_board.pop()
                 current_max_eval = max(current_max_eval, eval_score)
                 alpha = max(alpha, eval_score)
@@ -130,7 +131,7 @@ class Engine:
             for move in legal_moves_ab:
                 current_board.push(move)
                 # Next player (White) is maximizing. Depth is current_depth - 1.
-                eval_score = self.alpha_beta_search(current_board, depth - 1, alpha, beta, True, original_fen_for_eval)
+                eval_score = self.alpha_beta_search(current_board, depth - 1, alpha, beta, True, fen_of_board_at_this_level)
                 current_board.pop()
                 current_min_eval = min(current_min_eval, eval_score)
                 beta = min(beta, eval_score)


### PR DESCRIPTION
…t parent FEN for evaluation.

Previously, the alpha-beta search was passing the FEN of the root board state to the evaluation function for all leaf nodes in the search tree. This is incorrect if your evaluation model expects the 'first' FEN argument to be the parent of the 'second' FEN (the state being evaluated).

This change modifies the `alpha_beta_search` function:
1. It now takes a `parent_fen_for_eval` parameter instead of `original_fen_for_eval`.
2. For terminal nodes (depth 0 or non-checkmate game over), `evaluate_pos` is called with this `parent_fen_for_eval`.
3. When making recursive calls, `alpha_beta_search` now passes the FEN of the current board (before the move) as the `parent_fen_for_eval` for the next level of the search.

The `make_move_alpha_beta` function was already correctly passing its `original_fen_for_eval` (the root FEN for the current turn's search) as the initial `parent_fen_for_eval`, so no changes were needed there.

This change should improve the accuracy of board evaluations during search, addressing the issue of the engine making random or poor moves due to incorrect evaluation context.