### PR TITLE
Fix: Correct engine evaluation perspective in alpha-beta search

### DIFF
--- a/chess_engine.py
+++ b/chess_engine.py
@@ -17,14 +17,22 @@ def make_x(first,second):
     x_2 = np.array(x_2, dtype=np.float32).reshape(1,769)
     return x_1, x_2
 
-# evaluate two input positions
-def evaluate_pos(first, second):
-    x_1, x_2 = make_x(first,second)
+# get raw model evaluation for two input positions
+def get_raw_model_evaluation(first_fen, second_fen):
+    x_1, x_2 = make_x(first_fen,second_fen)
     interpreter.set_tensor(input_details[0]['index'], x_1)
     interpreter.set_tensor(input_details[1]['index'], x_2)
     interpreter.invoke()
     evaluation = interpreter.get_tensor(output_details[0]['index'])[0][0]
     return evaluation
+
+# evaluate two input positions, adjusting score based on whose turn it was in the first FEN
+def evaluate_pos(first_fen, second_fen):
+    raw_score = get_raw_model_evaluation(first_fen, second_fen)
+    board = chess.Board(first_fen)
+    if board.turn == chess.BLACK:
+        return -raw_score
+    return raw_score
 
 CHECKMATE_POSITIVE_SCORE = 9999
 CHECKMATE_NEGATIVE_SCORE = -9999


### PR DESCRIPTION
The chess engine was making poor moves due to an issue with how move evaluations were handled in the alpha-beta search algorithm. The `evaluate_pos` function, which scores a board transition using a neural network, was implicitly returning scores from the perspective of the player whose turn it was. However, the alpha-beta search logic assumed a consistent score perspective.

This commit addresses the issue by:
1. Renaming the original `evaluate_pos` to `get_raw_model_evaluation`.
2. Introducing a new `evaluate_pos` wrapper function. This function calls `get_raw_model_evaluation` and then normalizes the score to always be from White's perspective (positive for White's advantage, negative for Black's). If the raw score was from Black's turn, it's negated.
3. The `alpha_beta_search` and `make_move_alpha_beta` functions now use this normalized score. This ensures that White always tries to maximize the score, and Black always tries to minimize it, aligning the search algorithm with the evaluation output.

This change should result in the engine making more strategically sound moves.